### PR TITLE
Add GitHub Actions workflow for portfolio deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: Portfolio Deployment
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-scret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-south-1n
+
+    - name: Deploy static site to S3 bucket
+      run: aws s3 sync . s3://karangulve-portfolio --delete


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automated deployment of the portfolio site. The workflow is triggered on pushes to the `main` branch and sets up steps for building and deploying the static site to an AWS S3 bucket.

**Deployment automation:**

* Added `.github/workflows/main.yml` to define a GitHub Actions workflow named "Portfolio Deployment" that runs on pushes to the `main` branch.
* Configured steps to check out the repository, set up AWS credentials, and deploy the static site to the `karangulve-portfolio` S3 bucket using `aws s3 sync`.This workflow automates the deployment of the portfolio to an S3 bucket upon pushes to the main branch.